### PR TITLE
Add ability for user to specify custom short url

### DIFF
--- a/url_shortener/__init__.py
+++ b/url_shortener/__init__.py
@@ -63,7 +63,13 @@ def shorten_url():
             url = 'http://' + request.json['url']
         else:
             url = request.json['url']
-        res = shrt.shorten(url)
+
+        if 'surl' in request.json.keys():
+            surl = request.form['surl'].split()[0].lower()
+            res = shrt.shorten(url, surl)
+        else:
+            res = shrt.shorten(url)
+
         logger.debug("shortened %s to %s" % (url, res))
         response = make_response(json.dumps(res))
         response.headers['Content-Type'] = 'application/json'
@@ -75,7 +81,13 @@ def shorten_url():
             url = 'http://' + request.form['url']
         else:
             url = request.form['url']
-        res = shrt.shorten(url)
+
+        if request.form['surl'] == 'Optional, ShortURL':
+            surl = None
+        else:
+            surl = request.form['surl'].split()[0].lower()
+
+        res = shrt.shorten(url, surl)
         logger.debug("shortened %s to %s" % (url, res))
         return render_template('result.html', result=res)
 

--- a/url_shortener/__init__.py
+++ b/url_shortener/__init__.py
@@ -82,7 +82,7 @@ def shorten_url():
         else:
             url = request.form['url']
 
-        if request.form['surl'] == 'Optional, ShortURL':
+        if request.form['surl'] == 'Optional, ShortURL' or request.form['surl'] == '':
             surl = None
         else:
             surl = request.form['surl'].split()[0].lower()

--- a/url_shortener/shorten.py
+++ b/url_shortener/shorten.py
@@ -30,7 +30,7 @@ class UrlShortener:
         """
         return base64.b64encode(md5.new(url).digest()[-4:]).replace('=','').replace('/','_')
 
-    def shorten(self, url):
+    def shorten(self, url, code=None):
         """
         The shortening workflow is very minimal. We try to
         set the redis key to the url value. We catch any
@@ -38,7 +38,8 @@ class UrlShortener:
         in the client
         """
 
-        code = self.shortcode(url)
+        if not code:
+            code = self.shortcode(url)
         
         try:
             self.redis.set(config.REDIS_PREFIX + code, url)

--- a/url_shortener/static/js/js.js
+++ b/url_shortener/static/js/js.js
@@ -1,0 +1,12 @@
+function inputFocus(i) {
+    if (i.value == i.defaultValue) {
+        i.value = "";
+        i.style.color = "#000";
+    }
+}
+function inputBlur(i) {
+    if (i.value == "") {
+        i.value = i.defaultValue;
+        i.style.color = "#888";
+    }
+}

--- a/url_shortener/templates/index.html
+++ b/url_shortener/templates/index.html
@@ -3,15 +3,18 @@
 {% block body %}
 <div class="row-fluid">
   <div class="span6 offset4">
-
     <p>Enter a URL to shorten</p>
     <form id="shortener" method="POST" action="/">
       <div class="input-append">
-	<input class="span4" id="url" name="url" type="text">
-	<button class="btn" type="submit">Shorten</button>
+        <input class="span4" id="url" name="url" type="text" onfocus="inputFocus(this)"
+          onblur="inputBlur(this)" value="Long URL"><br>
+        <input class="span4" id="surl" name="surl" type="text" onfocus="inputFocus(this)"
+          onblur="inputBlur(this)" value="Optional, ShortURL"><br>
+	    <button class="btn" type="submit">Shorten</button>
       </div>
     </form>
   </div>
 </div>
+<script src="/static/js/js.js"></script>
 {% endblock body %}
 


### PR DESCRIPTION
This PR adds the ability for the user to add a custom short URL via the web form or via the API. If no custom short URL is specified, the default logic is used (part of the the default MD5 hash is used).

There are no tests with this code, however, it seems to work fine. 
